### PR TITLE
Remove trailing spaces in README and README_EN

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Sobre o sistema
 
-Veja o hotsite para divulgação do sistema: http://sistemacode.github.io    
+Veja o hotsite para divulgação do sistema: http://sistemacode.github.io
 
 O Controle de Ocorrências de Desempenho Escolar, C.O.D.E, é um software desenvolvido com o objetivo de controlar parte do processo de ocorrências e relatórios de desempenho escolar de forma prática e segura. Possui menus auto-explicativos e, futuramente, um manual eletrônico para o auxilo no manuseio do software, ou, para usuários mais avançados, a adaptação de novos sistemas baseados em seu código fonte.
 Sendo assim, pode-se dizer que o Sistema de Gestão de Ocorrências de Desempenho Escolar é de fácil operação e automatiza as principais rotinas envolvidas no objetivo proposto.
@@ -45,7 +45,7 @@ OBS: Existem várias formas de se criar um ambiente de execução, fique a vonta
     rvm use ruby --default &&
     rvm rubygems current
 
-**Apenas para ambiente de produção**    
+**Apenas para ambiente de produção**
 
     gem install passenger &&
     sudo apt-get install libpq-dev &&

--- a/README_EN.md
+++ b/README_EN.md
@@ -17,7 +17,7 @@ Thus, it can be said that the C.O.D.E is easy to operate and automate the main r
 The C.O.D.E was developed using the Ruby programming language with the Rails Framework and PostgreSQL database. So for it to run, you need an environment that contains all of these characteristics. If you do not, follow the steps in **Creating the environment for executing the C.O.D.E**. If you already have an environment, go to **Installing C.O.D.E**
 
 ## Creating the environment for executing the C.O.D.E
-***(Debian-based distributions)***    
+***(Debian-based distributions)***
 NOTE: There are several ways to create an execution environment, feel free to choose the most convenient way for you.
 
 ### First, install PostgreSQL
@@ -26,7 +26,7 @@ NOTE: There are several ways to create an execution environment, feel free to ch
 
 ### Then, change the user's password by following the steps below
 
-    sudo su - postgres    
+    sudo su - postgres
     psql -c "ALTER USER postgres WITH PASSWORD 'new_password'"
     sudo service postgresql restart
 
@@ -41,7 +41,7 @@ NOTE: There are several ways to create an execution environment, feel free to ch
     rvm use ruby --default &&
     rvm rubygems current
 
-**Only production environment**    
+**Only production environment**
 
     gem install passenger &&
     sudo apt-get install libpq-dev &&
@@ -85,4 +85,4 @@ If all the steps above have been performed properly, you are able to use the sys
 Access the address (if running locally `http://localhost:3000`) and use the User sown earlier.
 `admin@admin.com.br` and password `12345678`
 ______
-Created with <3 by Luiz Picolos 
+Created with <3 by Luiz Picolos


### PR DESCRIPTION
This PR removes all trailing spaces in  README and README_EN

With ❤️ 
