### PR TITLE
Troca therubyracer por mini_racer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
+sudo: required
+dist: trusty
 rvm:
   - 2.3.1
-
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler -v 1.13.2
 before_script:
   - cp config/application.yml.example config/application.yml
   - cp config/database.yml.example config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -59,5 +59,5 @@ end
 group :staging, :production do
   gem 'passenger'
   gem 'pg'
-  gem 'therubyracer'
+  gem 'mini_racer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       rails
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.15)
+    libv8 (5.0.71.48.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -161,6 +161,8 @@ GEM
       rake
     mini_magick (4.5.1)
     mini_portile2 (2.1.0)
+    mini_racer (0.1.4)
+      libv8 (~> 5.0, < 5.1.11)
     minitest (5.9.1)
     modernizr-rails (2.7.1)
     multi_json (1.12.1)
@@ -222,7 +224,6 @@ GEM
       rake
     record_tag_helper (1.0.0)
       actionview (~> 5.x)
-    ref (2.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.4)
@@ -272,9 +273,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -328,6 +326,7 @@ DEPENDENCIES
   kaminari-i18n
   mina
   mini_magick
+  mini_racer
   modernizr-rails
   passenger
   pdfkit
@@ -349,7 +348,6 @@ DEPENDENCIES
   simplecov (= 0.11.1)
   spring
   sprockets-rails
-  therubyracer
   turbolinks
   uglifier (>= 1.3.0)
   wkhtmltopdf-binary
@@ -358,4 +356,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.1
+   1.13.2


### PR DESCRIPTION
Troca a biblioteca therubyracer pela mini_racer que utiliza uma versão mais nova da libv8 causando menos problemas de incompatibilidade e um bom ganho de performance.

Mais em https://github.com/discourse/mini_racer
