### PR TITLE
Modificada a porta do banco de dados

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'uglifier', '>= 1.3.0'
 gem 'wkhtmltopdf-binary'
 gem 'record_tag_helper', '~> 1.0'
 
-
 group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,11 @@ services:
   postgres:
     image: postgres
     ports:
-      - "5432:5432"
+      - "54322:5432"
     environment:
       POSTGRES_DB: code_dev
       POSTGRES_USER: postgres
+      POSTGRES_PORT: '54322'
       POSTGRES_PASSWORD: postgres
   code:
     build: .
@@ -20,5 +21,5 @@ services:
     environment:
       DATABASE_URL: postgres
       DATABASE_USERNAME: postgres
+      DATABASE_PORT: '54322'
       DATABASE_PASSWORD: postgres
-


### PR DESCRIPTION
Como forma de manter o sistema code desvinculado de qualquer dependência resolvi modificar a porta do Postgres. Sendo assim, mesmo se o usuário possuir um database instalado, o sistema não será afetado.  
