### PR TITLE
Attach js to the turbolink load event

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 //= require alert_message
 //= require turbolinks
 
-$(document).ready(function() {
+$(document).on('turbolinks:load', function() {
   // Jquery ui
   $('.datepicker').datepicker();
 


### PR DESCRIPTION
As we are using turbolinks, the page does not reload. So that we have to attach to a different event, instead of using `ready`
Closes #49 
